### PR TITLE
added value extensions for safely returning from parse

### DIFF
--- a/src/Machete.HL7.Tests/AdvancedQueryTests.cs
+++ b/src/Machete.HL7.Tests/AdvancedQueryTests.cs
@@ -44,7 +44,7 @@ DG1|1|I9|788.64^URINARY HESITANCY^I9|URINARY HESITANCY
 OBX|1||URST^Urine Specimen Type^^^||URN
 NTE|1||abc
 NTE|2||dsa";
-            
+
             ParsedResult<HL7Entity> parsed = Parser.Parse(message);
 
             var result = parsed.Query(q =>
@@ -64,7 +64,7 @@ NTE|2||dsa";
                     {
                         OBR = obr,
                         DG1 = dg1,
-                        OBX = obx,
+                        OBX = obx
                     };
 
                 var testQuery = from orc in q.Select<ORC>()
@@ -76,6 +76,8 @@ NTE|2||dsa";
                     };
 
                 return from msh in q.Select<MSH>()
+                       from nte in q.Select<NTE>().ZeroOrMore()
+                       from pid in q.Select<PID>().ZeroOrMore()
                     from ignored in q.Except<HL7Segment, ORC>().ZeroOrMore()
                     from orders in testQuery.ZeroOrMore()
                     select new

--- a/src/Machete.HL7.Tests/EscapeCharacterTests.cs
+++ b/src/Machete.HL7.Tests/EscapeCharacterTests.cs
@@ -1,0 +1,32 @@
+﻿namespace Machete.HL7.Tests
+{
+    using HL7Schema.V26;
+    using NUnit.Framework;
+    using Testing;
+
+    [TestFixture]
+    public class EscapeCharacterTests :
+        HL7MacheteTestHarness<MSH, HL7Entity>
+    {
+        [Test, Explicit("Not working until Issue #20 is fixed")]
+        public void Test()
+        {
+            const string message =
+                @"MSH|^~\&|MACHETELAB|^DOSC|MACHETE|18779|20130405125146269||ORM^O01|1999077678|P|2.3|||AL|AL
+PID|1|000000000026|60043^^^MACHETE^MRN||MACHETE^JOE||19890909|F|||123 A \T\ B STREET^^Oakland^CA^94600||5101234567|5101234567||||||||||||||||N";
+
+            var parsed = Parser.Parse(message);
+            var result = parsed.Query(q => from msh in q.Select<MSH>()
+                from pid in q.Select<PID>()
+                select pid);
+
+            string street = result
+                .Get(x => x.PatientAddress, 0)
+                .Get(x => x.StreetAddress)
+                .Get(x => x.StreetName)
+                .ValueOrDefault();
+            
+            Assert.AreEqual(@"123 A & B STREET", street);
+        }
+    }
+}

--- a/src/Machete.HL7.Tests/GetValueExtensionsTests.cs
+++ b/src/Machete.HL7.Tests/GetValueExtensionsTests.cs
@@ -1,0 +1,67 @@
+﻿namespace Machete.HL7.Tests
+{
+    using NUnit.Framework;
+    using Segments;
+    using Testing;
+
+    [TestFixture]
+    public class GetValueExtensionsTests :
+        HL7MacheteTestHarness<TestHL7Entity, HL7Entity>
+    {
+        [Test]
+        public void Verify_Get_can_safely_return_value()
+        {
+            const string message1 = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234||ORU^R01|K113|P|";
+
+            Parsed<HL7Entity> parsed = Parser.Parse(message1);
+
+            var query = parsed.CreateQuery(q =>
+                from x in q.Select<MSHSegment>()
+                select x);
+
+            var result = parsed.Query(query);
+
+            string actual = result.Get(x => x.ReceivingApplication).ValueOrDefault();
+
+            Assert.AreEqual("MACHETE", actual);
+        }
+
+        [Test]
+        public void Verify_Get_can_safely_return_value_from_component()
+        {
+            const string message1 = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234||ORU^R01|K113|P|";
+
+            Parsed<HL7Entity> parsed = Parser.Parse(message1);
+
+            var query = parsed.CreateQuery(q =>
+                from x in q.Select<MSHSegment>()
+                select x);
+
+            var result = parsed.Query(query);
+
+            string actual = result.Get(x => x.MessageType).Get(x => x.MessageCode).ValueOrDefault();
+
+            Assert.AreEqual("ORU", actual);
+        }
+
+        [Test, Explicit("Not working until Issue #20 is fixed")]
+        public void Verify_Get_can_safely_return_value_from_array_component()
+        {
+            const string message1 = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234||ORU^R01|K113|P|
+VL1|ABC~XYZ~123";
+
+            Parsed<HL7Entity> parsed = Parser.Parse(message1);
+
+            var query = parsed.CreateQuery(q =>
+                from msh in q.Select<MSHSegment>()
+                from vl1 in q.Select<ValueListSegment>()
+                select vl1);
+
+            var result = parsed.Query(query);
+
+            string actual = result.Get(x => x.RepeatedString, 1).ValueOrDefault();
+
+            Assert.AreEqual("XYZ", actual);
+        }
+    }
+}

--- a/src/Machete.HL7.Tests/Machete.HL7.Tests.csproj
+++ b/src/Machete.HL7.Tests/Machete.HL7.Tests.csproj
@@ -47,6 +47,8 @@
     <Compile Include="ConditionallyParse_Specs.cs" />
     <Compile Include="ContextSetup.cs" />
     <Compile Include="DateTimeExtensionsTests.cs" />
+    <Compile Include="EscapeCharacterTests.cs" />
+    <Compile Include="GetValueExtensionsTests.cs" />
     <Compile Include="Query_Specs.cs" />
     <Compile Include="SchemaParser_Specs.cs" />
     <Compile Include="Segments\DateTimeSegment.cs" />
@@ -62,6 +64,8 @@
     <Compile Include="Segments\OptionalMessageLayout.cs" />
     <Compile Include="Segments\OptionalMessageLayoutMap.cs" />
     <Compile Include="Segments\TestHL7Entity.cs" />
+    <Compile Include="Segments\ValueListSegment.cs" />
+    <Compile Include="Segments\ValueListSegmentMap.cs" />
     <Compile Include="Template_Specs.cs" />
     <Compile Include="Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -69,6 +73,7 @@
     <Compile Include="Using_the_schema.cs" />
     <Compile Include="ValueDefaultExtensionsTests.cs" />
     <Compile Include="ValueExtensionsTests.cs" />
+    <Compile Include="ValueListTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Machete.HL7Schema\Machete.HL7Schema.csproj">

--- a/src/Machete.HL7.Tests/Segments/ValueListSegment.cs
+++ b/src/Machete.HL7.Tests/Segments/ValueListSegment.cs
@@ -1,0 +1,8 @@
+namespace Machete.HL7.Tests.Segments
+{
+    public interface ValueListSegment :
+        HL7Segment
+    {
+        ValueList<string> RepeatedString { get; }
+    }
+}

--- a/src/Machete.HL7.Tests/Segments/ValueListSegmentMap.cs
+++ b/src/Machete.HL7.Tests/Segments/ValueListSegmentMap.cs
@@ -1,0 +1,13 @@
+﻿namespace Machete.HL7.Tests.Segments
+{
+    public class ValueListSegmentMap :
+        HL7SegmentMap<ValueListSegment, HL7Segment>
+    {
+        public ValueListSegmentMap()
+        {
+            Id = "VL1";
+            
+            Value(x => x.RepeatedString, 1);
+        }
+    }
+}

--- a/src/Machete.HL7.Tests/ValueExtensionsTests.cs
+++ b/src/Machete.HL7.Tests/ValueExtensionsTests.cs
@@ -8,12 +8,12 @@
     
     [TestFixture]
     public class ValueExtensionsTests :
-        HL7MacheteTestHarness<MSHSegment, HL7Entity>
+        HL7MacheteTestHarness<TestHL7Entity, HL7Entity>
     {
         [Test]
         public void Verify_ValueOrEmpty_returns_empty_when_field_missing()
         {
-            const string message = @"MSH|^~\&|LIFTLAB||UBERMED||201701131234|||K113|P|";
+            const string message = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234|||K113|P|";
 
             Parsed<HL7Entity> parsed = Parser.Parse(message);
 
@@ -29,7 +29,7 @@
         [Test]
         public void Verify_IsEqualTo_can_evaluate_subcomponent_field_correctly()
         {
-            const string message1 = @"MSH|^~\&|LIFTLAB||UBERMED||201701131234||ORU^R01|K113|P|";
+            const string message1 = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234||ORU^R01|K113|P|";
 
             Parsed<HL7Entity> parsed1 = Parser.Parse(message1);
 
@@ -39,7 +39,7 @@
 
             var result1 = parsed1.Query(query1);
 
-            const string message2 = @"MSH|^~\&|LIFTLAB||UBERMED||201701131234||ORU^R02|K113|P|";
+            const string message2 = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234||ORU^R02|K113|P|";
 
             Parsed<HL7Entity> parsed2 = Parser.Parse(message2);
 
@@ -57,7 +57,7 @@
         [Test]
         public void Verify_IsEqualTo_can_evaluate_component_field_correctly()
         {
-            const string message1 = @"MSH|^~\&|LIFTLAB||UBERMED||201701131234||ORU^R01|K113|P|";
+            const string message1 = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234||ORU^R01|K113|P|";
 
             Parsed<HL7Entity> parsed1 = Parser.Parse(message1);
 
@@ -67,7 +67,7 @@
 
             var result1 = parsed1.Query(query1);
 
-            const string message2 = @"MSH|^~\&|LIFTLAB||UBERMED||201701131234||ORU^R02|K113|P|";
+            const string message2 = @"MSH|^~\&|LIFTLAB||MACHETE||201701131234||ORU^R02|K113|P|";
 
             Parsed<HL7Entity> parsed2 = Parser.Parse(message2);
 

--- a/src/Machete.HL7.Tests/ValueListTests.cs
+++ b/src/Machete.HL7.Tests/ValueListTests.cs
@@ -1,0 +1,40 @@
+﻿namespace Machete.HL7.Tests
+{
+    using HL7Schema.V26;
+    using NUnit.Framework;
+    using Testing;
+
+    [TestFixture]
+    public class ValueListTests :
+        HL7MacheteTestHarness<MSH, HL7Entity>
+    {
+        [Test, Explicit("This test should be working but is not because TryGetValue on ValueList not working properly. Issue #20")]
+        public void Should_be_possible()
+        {
+            const string message =
+                @"MSH|^~\&|MACHETELAB|^DOSC|MACHETE|18779|20130405125146269||ORM^O01|1999077678|P|2.3|||AL|AL
+PID|1|000000000026|60043^^^MACHETE1^MRN~60044^^^MACHETE2^MRN~60045^^^MACHETE3^MRN||MACHETE^JOE||19890909|F|||123 SEASAME STREET^^Oakland^CA^94600||5101234567|5101234567||||||||||||||||N";
+
+            ParsedResult<HL7Entity> parsed = Parser.Parse(message);
+
+            var query = parsed.CreateQuery(q =>
+                from msh in q.Select<MSH>()
+                from pid in q.Select<PID>()
+                select pid);
+
+            var result = parsed.Query(query);
+
+            Value<CX> id;
+            ValueList<CX> patientIdentifierList = result.Value.PatientIdentifierList;
+            bool actualResult = patientIdentifierList.TryGetValue(0, out id);
+
+            Assert.IsNotNull(patientIdentifierList);
+            Assert.IsTrue(patientIdentifierList.HasValue);
+            //Assert.IsNotEmpty(patientIdentifierList);
+            Assert.IsTrue(actualResult);
+            Assert.AreEqual("60043", id.Value.IdNumber.ValueOrDefault());
+            Assert.AreEqual("MACHETE1", id.Value.AssigningAuthority.Value.NamespaceId);
+            Assert.AreEqual("MRN", id.Value.IdentifierTypeCode.ValueOrDefault());
+        }
+    }
+}

--- a/src/Machete.HL7/HL7ValueExtensions.cs
+++ b/src/Machete.HL7/HL7ValueExtensions.cs
@@ -1,0 +1,56 @@
+﻿namespace Machete.HL7
+{
+    using System;
+
+    public static class HL7ValueExtensions
+    {
+        // Need to be able to perform Get off of the segment as well as the value
+        // Need to figure out how to do this for anonymous data structutes as well if possible
+        public static Segment<TSegment> Get<TSchema, TCursor, TSegment>(this Result<Cursor<TSchema>, TCursor> source, Func<TCursor, Segment<TSegment>> getter)
+            where TSegment : HL7Entity
+        {
+            try
+            {
+                if (source == null || !source.HasValue)
+                    return Segment.Missing<TSegment>();
+
+                return getter(source.Value);
+            }
+            catch
+            {
+                return Segment.Missing<TSegment>();
+            }
+        }
+
+    }
+
+    public static class Segment
+    {
+        public static Segment<T> Missing<T>()
+            where T : HL7Entity
+        {
+            return SegmentCache<T>.MissingSegment;
+        }
+
+        static class SegmentCache<TSegment>
+            where TSegment : HL7Entity
+        {
+            public static readonly Segment<TSegment> MissingSegment = GetMissingSegment();
+
+            static Segment<TSegment> GetMissingSegment()
+            {
+                return new MissingSegment<TSegment>();
+            }
+        }
+    }
+    
+    public class MissingSegment<TSegment> :
+        Segment<TSegment>
+        where TSegment : HL7Entity
+    {
+        public Type EntityType => typeof(TSegment);
+        public bool IsPresent => false;
+        public bool HasValue => false;
+        public TSegment Value { get{throw new ValueMissingException("The value is missing.");} }
+    }
+}

--- a/src/Machete.HL7/Machete.HL7.csproj
+++ b/src/Machete.HL7/Machete.HL7.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Configuration\TemplateConfiguration\IHL7StructureConfigurator.cs" />
     <Compile Include="HL7StructureFactoryExtensions.cs" />
     <Compile Include="HL7ValueConverters.cs" />
+    <Compile Include="HL7ValueExtensions.cs" />
     <Compile Include="HL7Version.cs" />
     <Compile Include="Layouts\SegmentListProperty.cs" />
     <Compile Include="Layouts\SegmentProperty.cs" />

--- a/src/Machete/ValueExtensions.cs
+++ b/src/Machete/ValueExtensions.cs
@@ -62,6 +62,84 @@
         {
             return value != null && value.HasValue ? value : other;
         }
+
+        /// <summary>
+        /// Safely returns the <see cref="Value{TValue}"/> from the parsed result.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="getter"></param>
+        /// <typeparam name="TSchema"></typeparam>
+        /// <typeparam name="TCursor"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
+        public static Value<TResult> Get<TSchema, TCursor, TResult>(this Result<Cursor<TSchema>, TCursor> source, Func<TCursor, Value<TResult>> getter)
+        {
+            try
+            {
+                if (source == null || !source.HasValue)
+                    return Value.Missing<TResult>();
+
+                return getter(source.Value);
+            }
+            catch
+            {
+                return Value.Missing<TResult>();
+            }
+        }
+
+        /// <summary>
+        /// Safely returns the <see cref="Value{TValue}"/> from the parsed result.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="getter"></param>
+        /// <param name="index"></param>
+        /// <typeparam name="TSchema"></typeparam>
+        /// <typeparam name="TCursor"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
+        public static Value<TResult> Get<TSchema, TCursor, TResult>(this Result<Cursor<TSchema>, TCursor> source, Func<TCursor, ValueList<TResult>> getter, int index)
+        {
+            try
+            {
+                if (source == null || !source.HasValue)
+                    return Value.Missing<TResult>();
+
+                ValueList<TResult> list = getter(source.Value);
+                if (list == null || !list.HasValue || index < 0)
+                    return Value.Missing<TResult>();
+
+                Value<TResult> value;
+
+                return list.TryGetValue(index, out value) ? value : Value.Missing<TResult>();
+            }
+            catch
+            {
+                return Value.Missing<TResult>();
+            }
+        }
+
+        /// <summary>
+        /// Safely returns the <see cref="Value{TValue}"/> from a complex object.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="getter"></param>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
+        public static Value<TResult> Get<TSource, TResult>(this Value<TSource> source, Func<TSource, Value<TResult>> getter)
+        {
+            try
+            {
+                if (source == null || !source.HasValue)
+                    return Value.Missing<TResult>();
+
+                return getter(source.Value);
+            }
+            catch
+            {
+                return Value.Missing<TResult>();
+            }
+        }
     }
 
 


### PR DESCRIPTION
refactored value extensions

made failing unit tess for ValueList.TryGetValue